### PR TITLE
Run fetching of meta-data of tile files in parallel (for GTC-3035)

### DIFF
--- a/gfw_pixetl/pixetl_prep.py
+++ b/gfw_pixetl/pixetl_prep.py
@@ -3,17 +3,43 @@ from urllib.parse import urlparse
 
 import click
 
+from gfw_pixetl import get_module_logger
 from gfw_pixetl.sources import RasterSource
 from gfw_pixetl.utils import get_bucket, upload_geometries
 from gfw_pixetl.utils.aws import get_aws_files
 from gfw_pixetl.utils.google import get_gs_files
 from gfw_pixetl.utils.utils import DummyTile
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+LOGGER = get_module_logger(__name__)
 
 
 def get_key_from_vsi(vsi_path: str) -> str:
     key = vsi_path.split("/")[3:]
     return "/".join(key)
 
+
+def parallel_raster_source(uri) -> RasterSource:
+    return RasterSource(uri)
+
+
+def parallel_get_tiles(files) -> List[DummyTile]:
+    '''Given a potentially large list of tiles files, return the list of
+    DummyTile/RasterSource objects associated with each tile. Creating the
+    RasterSource objects can be slow, since it requires fetching meta-data for
+    each tile file (on S3).
+    '''
+
+    future_tiles = {}
+    tiles: List[DummyTile] = list()
+
+    with ProcessPoolExecutor(max_workers=16) as executor:
+        for uri in files:
+            future_tiles[executor.submit(parallel_raster_source, uri)] = uri
+    for future in as_completed(future_tiles):
+        src = future.result()
+        tiles.append(DummyTile({"geotiff": src}))
+    return tiles
 
 def create_geojsons(
     resources: List[Tuple[str, str, str]],
@@ -22,16 +48,21 @@ def create_geojsons(
     prefix: str,
     merge_existing: bool,
 ) -> None:
+    '''Create the tiles.geojson and extent.geojson associated with the TIF files in
+    the paths in resources list. If merge_existing is Ture, also look at the tiles
+    already under data-lake/{dataset}/{version}/{prefix}.
+    '''
     get_files = {"s3": get_aws_files, "gs": get_gs_files}
 
     tiles: List[DummyTile] = list()
 
     for provider, bucket, key in resources:
+        LOGGER.info(f"Fetch file names for {bucket}, {key}")
         files = get_files[provider](bucket, key)
 
-        for uri in files:
-            src = RasterSource(uri)
-            tiles.append(DummyTile({"geotiff": src}))
+        LOGGER.info("Fetching tile meta-data")
+        tiles.extend(parallel_get_tiles(files))
+        LOGGER.info("Done fetching tile meta-data")
 
     data_lake_bucket = get_bucket()
     target_prefix = f"{dataset}/{version}/{prefix.strip('/')}/"
@@ -40,9 +71,7 @@ def create_geojsons(
     existing_tiles = list()
     if merge_existing:
         existing_uris = get_aws_files(data_lake_bucket, target_prefix)
-        for uri in existing_uris:
-            src = RasterSource(uri)
-            existing_tiles.append(DummyTile({"geotiff": src}))
+        existing_tiles = parallel_get_tiles(existing_uris)
 
     upload_geometries.upload_geojsons(
         tiles,  # type: ignore
@@ -52,6 +81,10 @@ def create_geojsons(
         ignore_existing_tiles=not merge_existing,
     )
 
+
+# Example command that could be run locally to complete processing:
+#
+# ENV=production python ./gfw_pixetl/pixetl_prep.py --dataset jrc_global_forest_cover --version v2020 --prefix raster/epsg-3857/zoom_14/is_default2 s3://gfw-data-lake/jrc_global_forest_cover/v2020/raster/epsg-3857/zoom_14/is_default2/geotiff
 
 @click.command()
 @click.argument("urls", type=str)
@@ -98,3 +131,7 @@ def cli(
         resources.append((provider, bucket, key))
 
     create_geojsons(resources, dataset, version, prefix, merge_existing)
+
+
+if __name__ == "__main__":
+    cli()

--- a/gfw_pixetl/pixetl_prep.py
+++ b/gfw_pixetl/pixetl_prep.py
@@ -9,6 +9,7 @@ from gfw_pixetl.utils import get_bucket, upload_geometries
 from gfw_pixetl.utils.aws import get_aws_files
 from gfw_pixetl.utils.google import get_gs_files
 from gfw_pixetl.utils.utils import DummyTile
+from gfw_pixetl.settings.globals import GLOBALS
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 LOGGER = get_module_logger(__name__)
@@ -33,7 +34,7 @@ def parallel_get_tiles(files) -> List[DummyTile]:
     future_tiles = {}
     tiles: List[DummyTile] = list()
 
-    with ProcessPoolExecutor(max_workers=16) as executor:
+    with ProcessPoolExecutor(max_workers=min(16, GLOBALS.num_processes)) as executor:
         for uri in files:
             future_tiles[executor.submit(parallel_raster_source, uri)] = uri
     for future in as_completed(future_tiles):

--- a/gfw_pixetl/pixetl_prep.py
+++ b/gfw_pixetl/pixetl_prep.py
@@ -34,6 +34,7 @@ def parallel_get_tiles(files) -> List[DummyTile]:
     future_tiles = {}
     tiles: List[DummyTile] = list()
 
+    print("In parallel_get_tiles, # files:", len(files))
     with ProcessPoolExecutor(max_workers=min(16, GLOBALS.num_processes)) as executor:
         for uri in files:
             future_tiles[executor.submit(parallel_raster_source, uri)] = uri
@@ -57,12 +58,16 @@ def create_geojsons(
 
     tiles: List[DummyTile] = list()
 
+    print("In create_geojsons")
     for provider, bucket, key in resources:
+        print(f"Fetch file names for {bucket}, {key}")
         LOGGER.info(f"Fetch file names for {bucket}, {key}")
         files = get_files[provider](bucket, key)
 
+        print("Fetching tile meta-data")
         LOGGER.info("Fetching tile meta-data")
         tiles.extend(parallel_get_tiles(files))
+        print("Done fetching tile meta-data")
         LOGGER.info("Done fetching tile meta-data")
 
     data_lake_bucket = get_bucket()
@@ -74,6 +79,7 @@ def create_geojsons(
         existing_uris = get_aws_files(data_lake_bucket, target_prefix)
         existing_tiles = parallel_get_tiles(existing_uris)
 
+    print("Starting upload_geojsons")
     upload_geometries.upload_geojsons(
         tiles,  # type: ignore
         existing_tiles,  # type: ignore
@@ -81,6 +87,7 @@ def create_geojsons(
         prefix=target_prefix,
         ignore_existing_tiles=not merge_existing,
     )
+    print("Done upload_geojsons")
 
 
 # Example command that could be run locally to complete processing:

--- a/gfw_pixetl/utils/aws.py
+++ b/gfw_pixetl/utils/aws.py
@@ -48,6 +48,7 @@ def get_aws_files(
     s3_client = get_s3_client()
     paginator = s3_client.get_paginator("list_objects_v2")
 
+    print("get_aws_files")
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         try:
             contents = page["Contents"]
@@ -59,4 +60,5 @@ def get_aws_files(
             if any(key.endswith(ext) for ext in extensions):
                 files.append(f"/vsis3/{bucket}/{key}")
 
+    print("done get_aws_files")
     return files

--- a/scripts/delete_workspace
+++ b/scripts/delete_workspace
@@ -2,5 +2,5 @@
 
 set -e
 
-docker-compose -f terraform/docker/docker-compose.yml build
-docker-compose -f terraform/docker/docker-compose.yml run --entrypoint delete_workspace --rm  terraform "$@"
+docker compose -f terraform/docker/docker-compose.yml build
+docker compose -f terraform/docker/docker-compose.yml run --entrypoint delete_workspace --rm  terraform "$@"

--- a/scripts/develop
+++ b/scripts/develop
@@ -26,11 +26,11 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 
 if [ "${BUILD}" = true ]; then
-  docker-compose -f docker-compose.dev.yml --project-name gfw-pixetl_dev build pixetl_dev
+  docker compose -f docker-compose.dev.yml --project-name gfw-pixetl_dev build pixetl_dev
 fi
 
 set +e
-docker-compose -f docker-compose.dev.yml --project-name gfw-pixetl_dev run --rm --name pixetl_dev pixetl_dev "$@"
+docker compose -f docker-compose.dev.yml --project-name gfw-pixetl_dev run --rm --name pixetl_dev pixetl_dev "$@"
 exit_code=$?
-docker-compose -f docker-compose.dev.yml --project-name gfw-pixetl_dev down --remove-orphans
+docker compose -f docker-compose.dev.yml --project-name gfw-pixetl_dev down --remove-orphans
 exit $exit_code

--- a/scripts/infra
+++ b/scripts/infra
@@ -2,5 +2,5 @@
 
 set -e
 
-docker-compose -f terraform/docker/docker-compose.yml build
-docker-compose -f terraform/docker/docker-compose.yml run --rm terraform "$@"
+docker compose -f terraform/docker/docker-compose.yml build
+docker compose -f terraform/docker/docker-compose.yml run --rm terraform "$@"

--- a/scripts/terraform
+++ b/scripts/terraform
@@ -2,4 +2,4 @@
 
 set -e
 
-docker-compose -f terraform/docker/docker-compose.yml run --rm --entrypoint terraform --workdir /usr/local/src/terraform terraform "$@"
+docker compose -f terraform/docker/docker-compose.yml run --rm --entrypoint terraform --workdir /usr/local/src/terraform terraform "$@"

--- a/scripts/test
+++ b/scripts/test
@@ -32,11 +32,11 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 
 if [ "${BUILD}" = true ]; then
-  docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test build sut
+  docker compose -f docker-compose.test.yml --project-name gfw-pixetl_test build sut
 fi
 
 set +e
-docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test run --rm --name pixetl_test sut /usr/local/app/tests/"$*"
+docker compose -f docker-compose.test.yml --project-name gfw-pixetl_test run --rm --name pixetl_test sut /usr/local/app/tests/"$*"
 exit_code=$?
-docker-compose -f docker-compose.test.yml --project-name gfw-pixetl_test down --remove-orphans
+docker compose -f docker-compose.test.yml --project-name gfw-pixetl_test down --remove-orphans
 exit $exit_code


### PR DESCRIPTION
Run fetching of meta-data of tile files in parallel

When generating the tiles.geojson file, the creation of the RasterSource
objects for each tile involves fetching meta-data from the tile files
from S3, and this can be quite slow when proceeding in serial. So, make
changes to fetch the meta-data in parallel using ProcessPoolExecutor.

For 16 workers, this reduces the fetch time on my local machine by
factor of 5-6, so reduce a nearly two-hour process for processing 2800
tiles to 20 minutes.

This is to help complete GTC-3035.  Creating a tile cache at zoom 14 (and
even zoom 13) takes too long to just create the tiles.geojson, and our
batch jobs never run long enough to complete it, so the tile cache creation
fails.